### PR TITLE
Enables vertices to have more than one label

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -620,7 +620,8 @@ defmodule Graph do
       ...> Graph.vertex_labels(g, :a)
       [:foo, :bar]
 
-      iex> g = Graph.new |> Graph.add_vertex(:a, [:foo, :bar])
+      iex> g = Graph.new |> Graph.add_vertex(:a)
+      ...> g = Graph.label_vertex(g, :a, [:foo, :bar])
       ...> Graph.vertex_labels(g, :a)
       [:foo, :bar]
   """

--- a/lib/graph/serializers/dot.ex
+++ b/lib/graph/serializers/dot.ex
@@ -22,9 +22,13 @@ defmodule Graph.Serializers.DOT do
   end
 
   defp get_vertex_label(%Graph{vertex_labels: vl}, id, v) do
-    encode_label(Map.get(vl, id, v))
+    case Map.get(vl, id) do
+      []    -> encode_label(v)
+      label -> encode_label(label)
+    end
   end
 
+  defp encode_label([h|_] = label) when length(label) == 1, do: encode_label(h)
   defp encode_label(label) when is_binary(label), do: quoted(label)
   defp encode_label(label) when is_integer(label), do: Integer.to_string(label)
   defp encode_label(label) when is_float(label), do: Float.to_string(label)

--- a/test/graph_test.exs
+++ b/test/graph_test.exs
@@ -11,7 +11,7 @@ defmodule GraphTest do
     g = Graph.delete_vertex(g, :v1)
     g = Graph.add_vertex(g, :v1, :labelB)
 
-    assert :labelB = Graph.vertex_label(g, :v1)
+    assert [:labelB] = Graph.vertex_labels(g, :v1)
   end
 
   test "inspect" do


### PR DESCRIPTION
I know it's possible to assign complex labels to vertices, like `[:foo, :bar]`, but it would be nice if the handling of multiple labels could be internal to the library, since in several use cases you don't know beforehand all the labels for vertices. 

This could work like this (modified and extended from doctests for `Graph.label_vertex/3`):

```elixir
iex> g = Graph.new |> Graph.add_vertex(:a, :foo)
...> [:foo] = Graph.vertex_labels(g, :a)
...> g = Graph.label_vertex(g, :a, :bar)
...> Graph.vertex_labels(g, :a)
[:foo, :bar]

iex> g = Graph.new |> Graph.add_vertex(:a, [:foo, :bar])
...> Graph.vertex_labels(g, :a)
[:foo, :bar]
```

You could also receive both single terms and lists in `Graph.label_vertex/3`:

```elixir
iex> g = Graph.new |> Graph.add_vertex(:a)
...> g = Graph.label_vertex(g, :a, [:foo, :bar])
...> Graph.vertex_labels(g, :a)
[:foo, :bar]
```

This implies 2 breaking changes:

- The `s` added at the end of the original `Graph.vertex_label/2`.
- `Graph.vertex_labels/2` always returns a list.

I was careful not to break the .dot serialization (at least with the current tests), but maybe it is worth discussing including both the vertex name and labels in the generated .dot file.