### PR TITLE
failing test case for preorder dft with int vertices

### DIFF
--- a/test/reducer_test.exs
+++ b/test/reducer_test.exs
@@ -17,6 +17,16 @@ defmodule Graph.Reducer.Test do
     assert ^expected = Graph.Reducers.Dfs.map(g, fn v -> v end)
   end
 
+  test "first node of depth-first (preorder) with edge {1, 8000}" do
+    g = Graph.new
+    |> Graph.add_vertices([1, 8000])
+    |> Graph.add_edge(1, 8000)
+
+    assert 1 = Graph.Reducers.Dfs.map(g, fn v -> v end) |> List.first()
+    # NB the same applies to the preorder function
+    # assert 1 = Graph.preorder(g) |> List.first()
+  end
+
   test "can walk a graph breadth-first" do
     g = Graph.new
     |> Graph.add_vertices([:a, :b, :c, :d, :e, :f, :g])


### PR DESCRIPTION
not sure what is happening, but something weird is going on when vertices are integers.

I did not dig super deep, but it looks like the order of the vertices in the underlying MapSet determines the first vertex to be traversed.

I think that for BFT you sort the vertices first, which you don't do for DFT.

Also, this only fails for certain values, e.g. {1,9000} is fine