### PR TITLE
Edgelist serialization capability

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -140,6 +140,11 @@ defmodule Graph do
     Graph.Serializers.DOT.serialize(g)
   end
 
+  @spec to_edgelist(t) :: {:ok, binary} | {:error, term}
+  def to_edgelist(%__MODULE__{} = g) do
+    Graph.Serializers.Edgelist.serialize(g)
+  end
+
   @doc """
   Returns the number of edges in the graph.
 

--- a/lib/graph/serializer.ex
+++ b/lib/graph/serializer.ex
@@ -9,4 +9,37 @@ defmodule Graph.Serializer do
       @behaviour Graph.Serializer
     end
   end
+
+  def get_vertex_label(%Graph{vertex_labels: vl}, id, v) do
+    case Map.get(vl, id) do
+      []    -> encode_label(v)
+      label -> encode_label(label)
+    end
+  end
+
+  def encode_label([h|_] = label) when length(label) == 1, do: encode_label(h)
+  def encode_label(label) when is_binary(label), do: quoted(label)
+  def encode_label(label) when is_integer(label), do: Integer.to_string(label)
+  def encode_label(label) when is_float(label), do: Float.to_string(label)
+  def encode_label(label) when is_atom(label), do: quoted(Atom.to_string(label))
+  def encode_label(label), do: quoted("#{inspect label}")
+
+  def quoted(str) do
+    <<?", escape_quotes(str)::binary, ?">>
+  end
+  def escape_quotes(str) do
+    escape_quotes(str, "")
+  end
+  def escape_quotes(<<>>, acc), do: acc
+  def escape_quotes(<<?\\, ?\", rest::binary>>, acc) do
+    escape_quotes(rest, <<acc::binary, ?\\, ?\">>)
+  end
+  def escape_quotes(<<?\", rest::binary>>, acc) do
+    escape_quotes(rest, <<acc::binary, ?\\, ?\">>)
+  end
+  def escape_quotes(<<c::utf8, rest::binary>>, acc) do
+    escape_quotes(rest, <<acc::binary, c::utf8>>)
+  end
+
+  def indent(tabs), do: String.duplicate(" ", tabs*4)
 end

--- a/lib/graph/serializers/dot.ex
+++ b/lib/graph/serializers/dot.ex
@@ -4,6 +4,7 @@ defmodule Graph.Serializers.DOT do
   to a great many other formats using Graphviz, e.g. `dot -Tpng out.dot > out.png`.
   """
   use Graph.Serializer
+  alias Graph.Serializer
 
   def serialize(%Graph{type: type} = g) do
     type = if type == :directed, do: "digraph", else: "graph"
@@ -17,54 +18,23 @@ defmodule Graph.Serializers.DOT do
 
   defp serialize_nodes(%Graph{vertices: vertices} = g) do
     Enum.reduce(vertices, "", fn {id, v}, acc ->
-      acc <> indent(1) <> get_vertex_label(g, id, v) <> "\n"
+      acc <> Serializer.indent(1) <> Serializer.get_vertex_label(g, id, v) <> "\n"
     end)
-  end
-
-  defp get_vertex_label(%Graph{vertex_labels: vl}, id, v) do
-    case Map.get(vl, id) do
-      []    -> encode_label(v)
-      label -> encode_label(label)
-    end
-  end
-
-  defp encode_label([h|_] = label) when length(label) == 1, do: encode_label(h)
-  defp encode_label(label) when is_binary(label), do: quoted(label)
-  defp encode_label(label) when is_integer(label), do: Integer.to_string(label)
-  defp encode_label(label) when is_float(label), do: Float.to_string(label)
-  defp encode_label(label) when is_atom(label), do: quoted(Atom.to_string(label))
-  defp encode_label(label), do: quoted("#{inspect label}")
-
-  defp quoted(str) do
-    <<?", escape_quotes(str)::binary, ?">>
-  end
-  defp escape_quotes(str) do
-    escape_quotes(str, "")
-  end
-  defp escape_quotes(<<>>, acc), do: acc
-  defp escape_quotes(<<?\\, ?\", rest::binary>>, acc) do
-    escape_quotes(rest, <<acc::binary, ?\\, ?\">>)
-  end
-  defp escape_quotes(<<?\", rest::binary>>, acc) do
-    escape_quotes(rest, <<acc::binary, ?\\, ?\">>)
-  end
-  defp escape_quotes(<<c::utf8, rest::binary>>, acc) do
-    escape_quotes(rest, <<acc::binary, c::utf8>>)
   end
 
   defp serialize_edges(%Graph{type: type, vertices: vertices, out_edges: oe, edges: em} = g) do
     edges = Enum.reduce(vertices, [], fn {id, v}, acc ->
-      v_label = get_vertex_label(g, id, v)
+      v_label = Serializer.get_vertex_label(g, id, v)
       edges =
         oe
         |> Map.get(id, MapSet.new)
         |> Enum.flat_map(fn id2 ->
-          v2_label = get_vertex_label(g, id2, Map.get(vertices, id2))
+          v2_label = Serializer.get_vertex_label(g, id2, Map.get(vertices, id2))
           Enum.map(Map.fetch!(em, {id, id2}), fn
             {nil, weight} ->
               {v_label, v2_label, weight}
             {label, weight} ->
-              {v_label, v2_label, weight, encode_label(label)}
+              {v_label, v2_label, weight, Serializer.encode_label(label)}
           end)
         end)
       case edges do
@@ -75,11 +45,9 @@ defmodule Graph.Serializers.DOT do
     arrow = if type == :directed, do: "->", else: "--"
     Enum.reduce(edges, "", fn
       {v_label, v2_label, weight, edge_label}, acc ->
-        acc <> indent(1) <> v_label <> " #{arrow} " <> v2_label <> " [" <> "label=#{edge_label}; weight=#{weight}" <> "]\n"
+        acc <> Serializer.indent(1) <> v_label <> " #{arrow} " <> v2_label <> " [" <> "label=#{edge_label}; weight=#{weight}" <> "]\n"
       {v_label, v2_label, weight}, acc ->
-        acc <> indent(1) <> v_label <> " #{arrow} " <> v2_label <> " [" <> "weight=#{weight}" <> "]\n"
+        acc <> Serializer.indent(1) <> v_label <> " #{arrow} " <> v2_label <> " [" <> "weight=#{weight}" <> "]\n"
     end)
   end
-
-  defp indent(tabs), do: String.duplicate(" ", tabs*4)
 end

--- a/lib/graph/serializers/edgelist.ex
+++ b/lib/graph/serializers/edgelist.ex
@@ -7,7 +7,6 @@ defmodule Graph.Serializers.Edgelist do
   use Graph.Serializer
   alias Graph.Serializer
 
-  @doc "Serialize a `Graph` object to an edgelist"
   @spec serialize(Graph.t()) :: {:ok, String.t()}
   def serialize(g) do
     result = "#{serialize_edges(g)}\n"
@@ -27,10 +26,10 @@ defmodule Graph.Serializers.Edgelist do
         {v_label, v2_label}
       end)
 
-        case edges do
-          [] -> acc
-          _ -> acc ++ edges
-        end
+      case edges do
+        [] -> acc
+        _ -> acc ++ edges
+      end
     end)
     |> Enum.map(fn {v_label, v2_label} -> "#{v_label} #{v2_label}" end)
     |> Enum.join("\n")

--- a/lib/graph/serializers/edgelist.ex
+++ b/lib/graph/serializers/edgelist.ex
@@ -1,0 +1,38 @@
+defmodule Graph.Serializers.Edgelist do
+  @moduledoc """
+  This serializer converts a `Graph` to an edgelist suitable for using with
+  graph libraries such as the polyglot igraph library.
+  """
+
+  use Graph.Serializer
+  alias Graph.Serializer
+
+  @doc "Serialize a `Graph` object to an edgelist"
+  @spec serialize(Graph.t()) :: {:ok, String.t()}
+  def serialize(g) do
+    result = "#{serialize_edges(g)}\n"
+
+    {:ok, result}
+  end
+
+  @spec serialize_edges(Graph.t()) :: String.t()
+  defp serialize_edges(%Graph{vertices: vertices, out_edges: oe} = g) do
+    Enum.reduce(vertices, [], fn {id, v}, acc ->
+      v_label = Serializer.get_vertex_label(g, id, v)
+      edges =
+        oe
+        |> Map.get(id, MapSet.new)
+        |> Enum.map(fn id2 ->
+        v2_label = Serializer.get_vertex_label(g, id2, Map.get(vertices, id2))
+        {v_label, v2_label}
+      end)
+
+        case edges do
+          [] -> acc
+          _ -> acc ++ edges
+        end
+    end)
+    |> Enum.map(fn {v_label, v2_label} -> "#{v_label} #{v2_label}" end)
+    |> Enum.join("\n")
+  end
+end

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -2,14 +2,8 @@ defmodule Graph.SerializerTests do
   use ExUnit.Case, async: true
 
   test "to_dot/1" do
-    g =
-      Graph.new
-      |> Graph.add_vertices([:a, :b, :c, :d])
-      |> Graph.add_edges([{:a, :b, weight: 3}, {:b, :c, label: 5}, {:b, :d, label: 1.0}, {:c, :d}])
-      |> Graph.label_vertex(:a, :start)
-      |> Graph.label_vertex(:b, {:complex, :label})
-      |> Graph.label_vertex(:d, "finish")
-      |> Graph.update_labelled_edge(:b, :d, 1.0, weight: 3)
+    g = kitchen_sink_graph()
+
     assert {:ok, """
     strict digraph {
         "start"
@@ -22,5 +16,29 @@ defmodule Graph.SerializerTests do
         "c" -> "finish" [weight=1]
     }
     """} = Graph.to_dot(g)
+  end
+
+  test "to_edgelist" do
+    g = kitchen_sink_graph()
+
+    {:ok, actual} = Graph.to_edgelist(g)
+
+    expected =  """
+"start" "{:complex, :label}"
+"{:complex, :label}" "c"
+"{:complex, :label}" "finish"
+"c" "finish"
+"""
+    assert actual == expected
+  end
+
+  defp kitchen_sink_graph do
+    Graph.new
+    |> Graph.add_vertices([:a, :b, :c, :d])
+    |> Graph.add_edges([{:a, :b, weight: 3}, {:b, :c, label: 5}, {:b, :d, label: 1.0}, {:c, :d}])
+    |> Graph.label_vertex(:a, :start)
+    |> Graph.label_vertex(:b, {:complex, :label})
+    |> Graph.label_vertex(:d, "finish")
+    |> Graph.update_labelled_edge(:b, :d, 1.0, weight: 3)
   end
 end


### PR DESCRIPTION
Adding the ability to serialize a graph into the edgelist format used by the venerable [igraph](http://igraph.org/) library and others. Hopefully this will ease the burden of moving graphs from Elixir into other systems for manipulation, analysis, and study.

I moved some of the logic I needed from the DOT `Serializer` module into the base `Serializer` behavior module. Hopefully this wasn't too bad of a move. Happy to clean it up if it doesn't pass muster.

Thanks,
+Jonathan