### PR TITLE
Allow running Graph.Reducers.Bfs on graphs whose inbound edges have been deleted

### DIFF
--- a/test/reducer_test.exs
+++ b/test/reducer_test.exs
@@ -31,4 +31,21 @@ defmodule Graph.Reducer.Test do
     expected = [:a, :b, :d, :c, :f, :e, :g]
     assert ^expected = Graph.Reducers.Bfs.map(g, fn v -> v end)
   end
+
+  test "can walk a graph breadth-first, when the starting points had their in-edges deleted" do
+    g = Graph.new
+    |> Graph.add_vertices([:a, :b, :c, :d, :e, :f, :g])
+    |> Graph.add_edge(:a, :b)
+    |> Graph.add_edge(:a, :d)
+    |> Graph.add_edge(:b, :c)
+    |> Graph.add_edge(:b, :d)
+    |> Graph.add_edge(:c, :e)
+    |> Graph.add_edge(:d, :f)
+    |> Graph.add_edge(:f, :g)
+    |> Graph.add_edge(:b, :a) # Add this edge and then remove it
+    |> Graph.delete_edge(:b, :a)
+
+    expected = [:a, :b, :d, :c, :f, :e, :g]
+    assert ^expected = Graph.Reducers.Bfs.map(g, fn v -> v end)
+  end
 end


### PR DESCRIPTION
The bfs reducer populates the initial queue by including all vertices who do not appear in the graph's `in_edges`. This check isn't sufficient for the case where a vertex had an inbound edge, which is then deleted from the graph, leaving an empty set in it's place.