### PR TITLE
Fix type for `info/1`

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -49,6 +49,12 @@ defmodule Graph do
           vertices: %{vertex_id => vertex},
           type: graph_type
         }
+  @type graph_info :: %{
+    :num_edges => non_neg_integer(),
+    :num_vertices => non_neg_integer(),
+    :size_in_bytes => number(),
+    :type => :directed | :undirected
+  }
 
   @doc """
   Creates a new directed graph.
@@ -93,7 +99,7 @@ defmodule Graph do
       ...> match?(%{type: :directed, num_vertices: 4, num_edges: 2}, Graph.info(g))
       true
   """
-  @spec info(t) :: %{num_edges: non_neg_integer, num_vertices: non_neg_integer}
+  @spec info(t) :: graph_info()
   def info(%__MODULE__{type: type} = g) do
     %{
       type: type,


### PR DESCRIPTION
This PR just fixes type used for `info/1` to reflect functionality and make `dialyzer` happier.