### PR TITLE
Use ID as vertex label when generating DOT output

### DIFF
--- a/lib/graph/serializers/dot.ex
+++ b/lib/graph/serializers/dot.ex
@@ -14,27 +14,23 @@ defmodule Graph.Serializers.DOT do
 
   defp serialize_nodes(%Graph{vertices: vertices} = g) do
     Enum.reduce(vertices, "", fn {id, v}, acc ->
-      acc <> Serializer.indent(1) <> Serializer.get_vertex_label(g, id, v) <> "\n"
+      acc <> Serializer.indent(1) <> "#{id}" <> "[label=" <> Serializer.get_vertex_label(g, id, v) <> "]\n"
     end)
   end
 
-  defp serialize_edges(%Graph{type: type, vertices: vertices, out_edges: oe, edges: em} = g) do
+  defp serialize_edges(%Graph{type: type, vertices: vertices, out_edges: oe, edges: em} = _g) do
     edges =
-      Enum.reduce(vertices, [], fn {id, v}, acc ->
-        v_label = Serializer.get_vertex_label(g, id, v)
-
+      Enum.reduce(vertices, [], fn {id, _v}, acc ->
         edges =
           oe
           |> Map.get(id, MapSet.new())
           |> Enum.flat_map(fn id2 ->
-            v2_label = Serializer.get_vertex_label(g, id2, Map.get(vertices, id2))
-
             Enum.map(Map.fetch!(em, {id, id2}), fn
               {nil, weight} ->
-                {v_label, v2_label, weight}
+                {id, id2, weight}
 
               {label, weight} ->
-                {v_label, v2_label, weight, Serializer.encode_label(label)}
+                {id, id2, weight, Serializer.encode_label(label)}
             end)
           end)
 
@@ -47,16 +43,16 @@ defmodule Graph.Serializers.DOT do
     arrow = if type == :directed, do: "->", else: "--"
 
     Enum.reduce(edges, "", fn
-      {v_label, v2_label, weight, edge_label}, acc ->
+      {v_id, v2_id, weight, edge_label}, acc ->
         acc <>
           Serializer.indent(1) <>
-          v_label <>
-          " #{arrow} " <> v2_label <> " [" <> "label=#{edge_label}; weight=#{weight}" <> "]\n"
+          "#{v_id}" <>
+          " #{arrow} " <> "#{v2_id}" <> " [" <> "label=#{edge_label}; weight=#{weight}" <> "]\n"
 
-      {v_label, v2_label, weight}, acc ->
+      {v_id, v2_id, weight}, acc ->
         acc <>
           Serializer.indent(1) <>
-          v_label <> " #{arrow} " <> v2_label <> " [" <> "weight=#{weight}" <> "]\n"
+          "#{v_id}" <> " #{arrow} " <> "#{v2_id}" <> " [" <> "weight=#{weight}" <> "]\n"
     end)
   end
 end


### PR DESCRIPTION
If you have vertices with the same label, the DOT output treats them as
the same vertex.

Use the raw ID to ensure that vertices aren't merged.