### PR TITLE
Fix bug where creating edges creates vertexes without label

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -2173,7 +2173,11 @@ defmodule Graph do
 
     Enum.reduce(allowed, Graph.new(type: type), fn v_id, sg ->
       v = Map.get(vertices, v_id)
-      sg = Graph.add_vertex(sg, v, Graph.vertex_labels(graph, v))
+      
+      sg =
+        sg
+        |> Graph.add_vertex(v)
+        |> Graph.label_vertex(v, Graph.vertex_labels(graph, v))
 
       oe
       |> Map.get(v_id, MapSet.new())


### PR DESCRIPTION
@bitwalker sorry for the noice, but I noticed a bug in my last PR. Adding the label needs to be an explicit update or it won't work for vertexes created in earlier iterations by adding the edges.