### PR TITLE
Fix Graph.topsort/1 spec

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -1458,7 +1458,7 @@ defmodule Graph do
       ...> Graph.topsort(g)
       false
   """
-  @spec topsort(t) :: [vertex]
+  @spec topsort(t) :: [vertex] | false
   def topsort(%__MODULE__{type: :undirected}), do: false
   def topsort(%__MODULE__{} = g), do: Graph.Directed.topsort(g)
 


### PR DESCRIPTION
Added `false` as an optional return value from `Graph.topsort/1`. Fixes dialyzer issues which arise when using the function.

E.g. The following code snippet:

```elixir
case Graph.sort(g) do
  false -> ...
  verts -> ...
end
```

Generates the following dialyzer error:
```
file.ex:line:pattern_match
The pattern can never match the type.

Pattern:
false

Type:
[any()]
```

