### PR TITLE
Fix typespec for `Graph.dijkstra/3`

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -318,7 +318,7 @@ defmodule Graph do
       ...> Graph.dijkstra(g, :a, :d)
       nil
   """
-  @spec dijkstra(t, vertex, vertex) :: [vertex]
+  @spec dijkstra(t, vertex, vertex) :: [vertex] | nil
   defdelegate dijkstra(g, a, b), to: Graph.Pathfinding
 
   @doc """


### PR DESCRIPTION
It delegates to `Graph.Pathfinding.dijkstra/3`, which can return `[vertex] | nil`, so it should too return `[vertex] | nil`