### PR TITLE
Add Mermaid Flowchart serializer

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -161,6 +161,11 @@ defmodule Graph do
     Graph.Serializers.Edgelist.serialize(g)
   end
 
+  @spec to_flowchart(t) :: {:ok, binary} | {:error, term}
+  def to_flowchart(%__MODULE__{} = g) do
+    Graph.Serializers.Flowchart.serialize(g)
+  end
+
   @doc """
   Returns the number of edges in the graph.
 

--- a/lib/graph/serializers/flowchart.ex
+++ b/lib/graph/serializers/flowchart.ex
@@ -1,0 +1,66 @@
+defmodule Graph.Serializers.Flowchart do
+  @moduledoc """
+  This serializer converts a `Graph` to a [Mermaid Flowchart](https://mermaid.js.org/syntax/flowchart.html).
+  """
+
+  use Graph.Serializer
+  import Graph.Serializer
+
+  @impl Graph.Serializer
+  def serialize(%Graph{} = g) do
+    result = """
+    ```mermaid
+    flowchart
+    #{serialize_vertices(g)}
+    #{serialize_edges(g)}
+    ```
+    """
+
+    {:ok, result}
+  end
+
+  defp serialize_vertices(g) do
+    Enum.map_join(g.vertices, "\n", fn {id, value} ->
+      indent(1) <> "#{id}" <> "[" <> get_vertex_label(g, id, value) <> "]"
+    end)
+  end
+
+  defp serialize_edges(g) do
+    arrow =
+      case g.type do
+        :directed -> "->"
+        :undirected -> "-"
+      end
+
+    g.vertices
+    |> Enum.reduce([], fn {id, _}, acc ->
+      g.out_edges
+      |> Map.get_lazy(id, &MapSet.new/0)
+      |> Enum.flat_map(fn out_edge_id ->
+        g.edges
+        |> Map.fetch!({id, out_edge_id})
+        |> Enum.map(fn
+          {nil, weight} -> {id, out_edge_id, weight}
+          {label, weight} -> {id, out_edge_id, weight, encode_label(label)}
+        end)
+      end)
+      |> case do
+        [] -> acc
+        edges -> acc ++ edges
+      end
+    end)
+    |> Enum.map_join("\n", &serialize_edge(&1, arrow))
+  end
+
+  defp serialize_edge({id, out_edge_id, weight, label}, arrow) do
+    indent(1) <> "#{id} " <> weight_arrow(arrow, weight) <> " |#{label}| " <> "#{out_edge_id}"
+  end
+
+  defp serialize_edge({id, out_edge_id, weight}, arrow) do
+    indent(1) <> "#{id} " <> weight_arrow(arrow, weight) <> " #{out_edge_id}"
+  end
+
+  defp weight_arrow(arrow, weight) do
+    String.duplicate("-", weight) <> arrow
+  end
+end

--- a/lib/graph/serializers/flowchart.ex
+++ b/lib/graph/serializers/flowchart.ex
@@ -9,11 +9,9 @@ defmodule Graph.Serializers.Flowchart do
   @impl Graph.Serializer
   def serialize(%Graph{} = g) do
     result = """
-    ```mermaid
     flowchart
     #{serialize_vertices(g)}
     #{serialize_edges(g)}
-    ```
     """
 
     {:ok, result}

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -40,7 +40,6 @@ defmodule Graph.SerializerTests do
     {:ok, actual} = Graph.to_flowchart(g)
 
     expected = """
-    ```mermaid
     flowchart
         97["start"]
         98["{:complex, :label}"]
@@ -50,7 +49,6 @@ defmodule Graph.SerializerTests do
         98 --> |5| 99
         98 ----> |1.0| 100
         99 --> 100
-    ```
     """
 
     assert actual == expected

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -34,6 +34,28 @@ defmodule Graph.SerializerTests do
     assert actual == expected
   end
 
+  test "to_flowchart" do
+    g = kitchen_sink_graph()
+
+    {:ok, actual} = Graph.to_flowchart(g)
+
+    expected = """
+    ```mermaid
+    flowchart
+        97["start"]
+        98["{:complex, :label}"]
+        99["c"]
+        100["finish"]
+        97 ----> 98
+        98 --> |5| 99
+        98 ----> |1.0| 100
+        99 --> 100
+    ```
+    """
+
+    assert actual == expected
+  end
+
   defp kitchen_sink_graph do
     Graph.new()
     |> Graph.add_vertices([:a, :b, :c, :d])


### PR DESCRIPTION
Adds a serializer for [Mermaid](https://mermaid.js.org/) [Flowcharts](https://mermaid.js.org/syntax/flowchart.html)

```mermaid
flowchart
    97["start"]
    98["{:complex, :label}"]
    99["c"]
    100["finish"]
    97 ----> 98
    98 --> |5| 99
    98 ----> |1.0| 100
    99 --> 100
```