### PR TITLE
add leaf_vertices function

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -604,7 +604,27 @@ defmodule Graph do
     Map.values(vs)
   end
 
-  defdelegate leaf_vertices(g), to: Graph.Directed
+  @doc """
+  Returns a list of all vertices that have no outgoing edges.
+
+  NOTE: This function is only supported for directed graphs, and
+  will return `{:error, :unsupported}` for undirected graphs.
+
+  ## Example
+
+      iex> g = Graph.new |> Graph.add_vertices([:a, :b, :c]) |> Graph.add_edges([{:a, :b}, {:b, :c}])
+      ...> Graph.leaf_vertices(g)
+      [:c]
+
+  """
+  @spec leaf_vertices(t) :: [vertex]
+  def leaf_vertices(%Graph{type: :undirected}) do
+    raise ArgumentError, "leaf_vertices/1 is not supported for undirected graphs"
+  end
+
+  def leaf_vertices(%Graph{type: :directed} = g) do
+    Graph.Directed.leaf_vertices(g)
+  end
 
   @doc """
   Returns true if the given vertex exists in the graph. Otherwise false.

--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -604,6 +604,8 @@ defmodule Graph do
     Map.values(vs)
   end
 
+  defdelegate leaf_vertices(g), to: Graph.Directed
+
   @doc """
   Returns true if the given vertex exists in the graph. Otherwise false.
 

--- a/lib/graph/directed.ex
+++ b/lib/graph/directed.ex
@@ -69,6 +69,17 @@ defmodule Graph.Directed do
       true
   end
 
+  def leaf_vertices(%Graph{in_edges: ie, out_edges: oe} = g) do
+    Enum.reduce(ie, [], fn {v_id, _}, acc ->
+      if Map.has_key?(oe, v_id) do
+        acc
+      else
+        vertex = Map.get(g.vertices, v_id)
+        [vertex | acc]
+      end
+    end)
+  end
+
   def loop_vertices(%Graph{vertices: vs} = g) do
     for {v_id, v} <- vs, is_reflexive_vertex(g, v_id), do: v
   end

--- a/lib/graph/directed.ex
+++ b/lib/graph/directed.ex
@@ -69,12 +69,11 @@ defmodule Graph.Directed do
       true
   end
 
-  def leaf_vertices(%Graph{in_edges: ie, out_edges: oe} = g) do
-    Enum.reduce(ie, [], fn {v_id, _}, acc ->
+  def leaf_vertices(%Graph{out_edges: oe, vertices: vc}) do
+    Enum.reduce(vc, [], fn {v_id, vertex}, acc ->
       if Map.has_key?(oe, v_id) do
         acc
       else
-        vertex = Map.get(g.vertices, v_id)
         [vertex | acc]
       end
     end)

--- a/test/graph_test.exs
+++ b/test/graph_test.exs
@@ -537,6 +537,11 @@ defmodule GraphTest do
     assert 20 = Graph.degeneracy(g)
   end
 
+  test "leaf_vertices/1" do
+    g = build_basic_acyclic_graph()
+    assert [:e] = Graph.leaf_vertices(g)
+  end
+
   defp build_basic_cyclic_graph do
     Graph.new()
     |> Graph.add_vertex(:a)


### PR DESCRIPTION
This is a rough draft to address https://github.com/bitwalker/libgraph/issues/68

I don't have a lot of experience with graph theory, so I wasn't sure if the idea of `leaf_vertices` usually includes root nodes? This current implementation only includes vertices that have an edge pointing to them, and no outgoing edges. In my application code I have a recursive process that scans for leaf vertices that need to be resolved and when there are no leaf vertices left it just grabs all remaining vertices to finish it's work.