### PR TITLE
Fix #73

### DIFF
--- a/lib/graph.ex
+++ b/lib/graph.ex
@@ -693,7 +693,7 @@ defmodule Graph do
     end
   end
 
-  def add_vertex(g, v, label) do
+  def add_vertex(%__MODULE__{} = g, v, label) when not is_list(label) do
     add_vertex(g, v, [label])
   end
 


### PR DESCRIPTION
Should fix #73. I prefer this to #75 as matching on `is_struct` rather than the specific `Graph` struct would just delay a crash if passing in `%NotAGraph{}`. The guards in this request are a bit more explicit.

add_vertex would loop infinitely if passed non-graph value as first parameter b/c it would always match the last function head def for add_vertex/3, which was a recursive call. Making all function heads match first parameter on %Graph{} should solve this issue.